### PR TITLE
Add support for Minecraft 1.21.6/1.21.7 (1_21_R5)

### DIFF
--- a/DisguiseAPI/src/main/java/dev/iiahmed/disguise/util/Version.java
+++ b/DisguiseAPI/src/main/java/dev/iiahmed/disguise/util/Version.java
@@ -106,6 +106,9 @@ public final class Version {
                     return "1_21_R3";
                 case "1.21.5":
                     return "1_21_R4";
+                case "1.21.6":
+                case "1.21.7":
+                    return "1_21_R5";
                 default:
                     return "UNKNOWN";
             }

--- a/ModernDisguise/pom.xml
+++ b/ModernDisguise/pom.xml
@@ -259,6 +259,13 @@
 
         <dependency>
             <groupId>dev.iiahmed</groupId>
+            <artifactId>VS-1_21_R5</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.iiahmed</groupId>
             <artifactId>VS-Fallback</artifactId>
             <version>${project.parent.version}</version>
             <scope>compile</scope>

--- a/ModernDisguise/src/main/java/dev/iiahmed/disguise/DisguiseManager.java
+++ b/ModernDisguise/src/main/java/dev/iiahmed/disguise/DisguiseManager.java
@@ -91,6 +91,9 @@ public final class DisguiseManager {
             case "1_21_R4":
                 PROVIDER = new VS1_21_R4();
                 break;
+            case "1_21_R5":
+                PROVIDER = new VS1_21_R5();
+                break;
             case "UNKNOWN":
             default:
                 PROVIDER = new VS_Unavailable();

--- a/VS-1_21_R5/pom.xml
+++ b/VS-1_21_R5/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>ModernDisguise-parent</artifactId>
+        <groupId>dev.iiahmed</groupId>
+        <version>3.6</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>VS-1_21_R5</artifactId>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.spigotVersion>1.21.7-R0.1-SNAPSHOT</project.spigotVersion>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>net.md-5</groupId>
+                <artifactId>specialsource-maven-plugin</artifactId>
+                <version>2.0.2</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>remap</goal>
+                        </goals>
+                        <id>remap-obf</id>
+                        <configuration>
+                            <srgIn>org.spigotmc:minecraft-server:${project.spigotVersion}:txt:maps-mojang</srgIn>
+                            <reverse>true</reverse>
+                            <remappedDependencies>org.spigotmc:spigot:${project.spigotVersion}:jar:remapped-mojang
+                            </remappedDependencies>
+                            <remappedArtifactAttached>true</remappedArtifactAttached>
+                            <remappedClassifierName>remapped-obf</remappedClassifierName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>remap</goal>
+                        </goals>
+                        <id>remap-spigot</id>
+                        <configuration>
+                            <inputFile>
+                                ${project.build.directory}/${project.artifactId}-${project.version}-remapped-obf.jar
+                            </inputFile>
+                            <srgIn>org.spigotmc:minecraft-server:${project.spigotVersion}:csrg:maps-spigot</srgIn>
+                            <remappedDependencies>org.spigotmc:spigot:${project.spigotVersion}:jar:remapped-obf
+                            </remappedDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.iiahmed</groupId>
+            <artifactId>DisguiseAPI</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>${project.spigotVersion}</version>
+            <classifier>remapped-mojang</classifier>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/VS-1_21_R5/src/main/java/dev/iiahmed/disguise/vs/VS1_21_R5.java
+++ b/VS-1_21_R5/src/main/java/dev/iiahmed/disguise/vs/VS1_21_R5.java
@@ -1,0 +1,123 @@
+package dev.iiahmed.disguise.vs;
+
+import dev.iiahmed.disguise.DisguiseProvider;
+import dev.iiahmed.disguise.Entity;
+import dev.iiahmed.disguise.attribute.Attribute;
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.*;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.PositionMoveRotation;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R5.CraftRegistry;
+import org.bukkit.craftbukkit.v1_21_R5.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+
+@SuppressWarnings("all")
+public final class VS1_21_R5 extends DisguiseProvider {
+
+    @Override
+    public void refreshAsPlayer(@NotNull final Player player) {
+        if (!player.isOnline()) {
+            return;
+        }
+        final Location location = player.getLocation();
+        final ServerPlayer ep = ((CraftPlayer) player).getHandle();
+        ep.connection.send(new ClientboundPlayerInfoRemovePacket(Collections.singletonList(ep.getUUID())));
+        ep.connection.send(
+                new ClientboundRespawnPacket(
+                        ep.createCommonSpawnInfo(ep.level()),
+                        ClientboundRespawnPacket.KEEP_ALL_DATA
+                )
+        );
+        player.teleport(location);
+        ep.getServer().getPlayerList().sendLevelInfo(ep, ep.level());
+        ep.connection.send(new ClientboundPlayerInfoUpdatePacket(
+                ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER,
+                ep));
+        ep.connection.send(new ClientboundPlayerInfoUpdatePacket(
+                ClientboundPlayerInfoUpdatePacket.Action.UPDATE_LISTED,
+                ep));
+        ep.containerMenu.sendAllDataToRemote(); // originally player.updateInventory();
+        for (final Player serverPlayer : Bukkit.getOnlinePlayers()) {
+            serverPlayer.hidePlayer(plugin, player);
+            serverPlayer.showPlayer(plugin, player);
+        }
+    }
+
+    @Override
+    public void refreshAsEntity(@NotNull final Player refreshed, final boolean remove, final Player... targets) {
+        if (!isDisguised(refreshed) || targets.length == 0 || !getInfo(refreshed).hasEntity()) {
+            return;
+        }
+
+        final ServerPlayer handle = ((CraftPlayer) refreshed).getHandle();
+        final Entity entity = getInfo(refreshed).getEntity();
+
+        final ClientboundAddEntityPacket spawn;
+        final Collection<AttributeInstance> attributesSet;
+        try {
+            final LivingEntity living = (LivingEntity) this.entityProvider.create(entity.getType(), handle.level());
+
+            for (final Map.Entry<Attribute, Double> entry : entity.getAttributes().entrySet()) {
+                final String name = entry.getKey().getKey();
+                final Holder<net.minecraft.world.entity.ai.attributes.Attribute> holder = CraftRegistry.getMinecraftRegistry(Registries.ATTRIBUTE).wrapAsHolder(
+                        CraftRegistry.getMinecraftRegistry(Registries.ATTRIBUTE).get(ResourceLocation.parse(name)).get().value()
+                );
+                living.getAttribute(holder).setBaseValue(entry.getValue());
+            }
+
+            attributesSet = living.getAttributes().getAttributesToUpdate();
+            spawn = new ClientboundAddEntityPacket(
+                    handle.getId(),
+                    living.getUUID(),
+                    handle.getX(),
+                    handle.getY(),
+                    handle.getZ(),
+                    handle.getXRot(),
+                    handle.getYRot(),
+                    living.getType(),
+                    0,
+                    handle.getDeltaMovement(),
+                    handle.getYHeadRot()
+            );
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        final ClientboundTeleportEntityPacket tp = new ClientboundTeleportEntityPacket(
+                handle.getId(),
+                PositionMoveRotation.of(handle),
+                Collections.emptySet(),
+                handle.onGround
+        );
+        final ClientboundUpdateAttributesPacket attributes = new ClientboundUpdateAttributesPacket(refreshed.getEntityId(), attributesSet);
+
+        final List<Packet<? super ClientGamePacketListener>> packets = new ArrayList<Packet<? super ClientGamePacketListener>>() {
+            {
+                if (remove) {
+                    add(new ClientboundRemoveEntitiesPacket(refreshed.getEntityId()));
+                }
+                add(spawn);
+                add(tp);
+                add(attributes);
+            }
+        };
+
+        final ClientboundBundlePacket bundlePacket = new ClientboundBundlePacket(packets);
+        for (final Player player : targets) {
+            if (player == refreshed) continue;
+            final ServerPlayer ep = ((CraftPlayer) player).getHandle();
+            ep.connection.send(bundlePacket);
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <module>VS-1_21_R2</module>
         <module>VS-1_21_R3</module>
         <module>VS-1_21_R4</module>
+        <module>VS-1_21_R5</module>
     </modules>
 
     <build>


### PR DESCRIPTION
Introduced the VS-1_21_R5 module with implementation for the new Minecraft 1.21.6 and 1.21.7 protocol. 
Updated version detection, dependency management, and DisguiseManager to support 1_21_R5. 
Registered the new module in the parent pom.xml and ModernDisguise dependencies.

I haven't tested on 1.21.6 nor on Spigot, though I can confirm it works on Paper 1.21.7 - Currently attempting to update my server from 1.21.4->1.21.7 and this is a key dependency for my AI integration <3 Thank you guys so much for making this project! 

I think everything matches up against the current code base, but if not feel free to disregard this pull request, just wanted to submit it in-case it's of any help!